### PR TITLE
Detect recent Jirama délestage posts

### DIFF
--- a/background.js
+++ b/background.js
@@ -12,9 +12,21 @@ function showNotification() {
   });
 }
 
+// Notifie lorsqu'un post de délestage récent est trouvé
+function showDelestageNotification() {
+  chrome.notifications.create({
+    type: "basic",
+    iconUrl: "icon.png",
+    title: "JIRAMA FB",
+    message: "⚡ Plan de délestage publié dans les dernières 24h"
+  });
+}
+
 // On écoute les messages venant du content script
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   if (request.action === "notify") {
     showNotification();
+  } else if (request.action === "notifyDelestage") {
+    showDelestageNotification();
   }
 });

--- a/content.js
+++ b/content.js
@@ -1,2 +1,34 @@
 // Dès que ce script s'exécute (car on est sur la bonne URL)
 chrome.runtime.sendMessage({ action: "notify" });
+
+// Vérifie la présence d'un post de délestage récent
+function checkDelestagePosts() {
+  const now = Date.now();
+  // Sélection des posts du flux
+  const posts = document.querySelectorAll('div[data-pagelet^="FeedUnit_"]');
+
+  for (const post of posts) {
+    const abbr = post.querySelector('abbr[data-utime]');
+    if (!abbr) continue;
+
+    const utime = parseInt(abbr.getAttribute('data-utime'), 10) * 1000;
+    if (Number.isNaN(utime)) continue;
+
+    // 24h = 24 * 60 * 60 * 1000 ms
+    if (now - utime <= 24 * 60 * 60 * 1000) {
+      const imgs = post.querySelectorAll('img');
+      for (const img of imgs) {
+        const alt = (img.getAttribute('alt') || '').toLowerCase();
+        const src = (img.getAttribute('src') || '').toLowerCase();
+        if (/d[eé]lestage/.test(alt) || /d[eé]lestage/.test(src)) {
+          chrome.runtime.sendMessage({ action: 'notifyDelestage' });
+          return; // On notifie une seule fois
+        }
+      }
+    }
+  }
+}
+
+// Laisse la page charger un peu avant de chercher les posts
+setTimeout(checkDelestagePosts, 3000);
+


### PR DESCRIPTION
## Summary
- notify when a recent post contains images indicating délestage
- add dedicated notification for detected délestage announcements

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b839d5a2048320a30627bf6e2df12c