### PR TITLE
Add 'délester' keyword support

### DIFF
--- a/content.js
+++ b/content.js
@@ -1,6 +1,9 @@
 // Dès que ce script s'exécute (car on est sur la bonne URL)
 chrome.runtime.sendMessage({ action: "notify" });
 
+// Liste des mots-clés à détecter
+const KEYWORDS = [/d[eé]lestage/, /d[eé]lester/];
+
 // Vérifie la présence d'un post de délestage récent
 function checkDelestagePosts() {
   const now = Date.now();
@@ -20,7 +23,7 @@ function checkDelestagePosts() {
       for (const img of imgs) {
         const alt = (img.getAttribute('alt') || '').toLowerCase();
         const src = (img.getAttribute('src') || '').toLowerCase();
-        if (/d[eé]lestage/.test(alt) || /d[eé]lestage/.test(src)) {
+        if (KEYWORDS.some((regex) => regex.test(alt) || regex.test(src))) {
           chrome.runtime.sendMessage({ action: 'notifyDelestage' });
           return; // On notifie une seule fois
         }


### PR DESCRIPTION
## Summary
- Detect both "délester" and "delester" in Facebook posts

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b83b8256b883209e2f35c0df59369d