### PR TITLE
feat: detect delestage template

### DIFF
--- a/background.js
+++ b/background.js
@@ -10,6 +10,7 @@ function showNotification() {
     title: "JIRAMA FB",
     message: "Tu es sur le Facebook officiel de la Jirama 🚰⚡"
   });
+  console.debug('Notification standard affichée');
 }
 
 // Notifie lorsqu'un post de délestage récent est trouvé
@@ -20,10 +21,12 @@ function showDelestageNotification() {
     title: "JIRAMA FB",
     message: "⚡ Plan de délestage publié dans les dernières 24h"
   });
+  console.debug('Notification de délestage affichée');
 }
 
 // On écoute les messages venant du content script
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+  console.debug('Message reçu du content script', request);
   if (request.action === "notify") {
     showNotification();
   } else if (request.action === "notifyDelestage") {

--- a/content.js
+++ b/content.js
@@ -11,7 +11,8 @@ const KEYWORDS = [
 ];
 
 // Vérifie la présence d'un post de délestage récent
-function checkDelestagePosts() {
+async function checkDelestagePosts() {
+  console.debug('Recherche des posts de délestage...');
   const now = Date.now();
   // Sélection des posts du flux
   const posts = document.querySelectorAll('div[data-pagelet^="FeedUnit_"]');
@@ -27,7 +28,9 @@ function checkDelestagePosts() {
     if (now - utime <= 24 * 60 * 60 * 1000) {
       // Vérifie d'abord le texte du post
       const text = (post.innerText || '');
+      console.debug('Analyse du texte du post', text.substring(0, 30));
       if (KEYWORDS.some((regex) => regex.test(text))) {
+        console.debug('Mot clé trouvé dans le texte');
         chrome.runtime.sendMessage({ action: 'notifyDelestage' });
         return;
       }
@@ -37,15 +40,69 @@ function checkDelestagePosts() {
       for (const img of imgs) {
         const alt = img.getAttribute('alt') || '';
         const src = img.getAttribute('src') || '';
+        console.debug('Analyse de l\'image', { alt, src });
         if (KEYWORDS.some((regex) => regex.test(alt) || regex.test(src))) {
+          console.debug('Mot clé trouvé dans l\'image');
           chrome.runtime.sendMessage({ action: 'notifyDelestage' });
           return; // On notifie une seule fois
+        }
+
+        // Tentative de reconnaissance du template JIRAMA
+        try {
+          if (await isDelestageTemplate(img)) {
+            console.debug('Template d\'image JIRAMA détecté');
+            chrome.runtime.sendMessage({ action: 'notifyDelestage' });
+            return;
+          }
+        } catch (e) {
+          console.debug('Erreur lors de l\'analyse de l\'image', e);
         }
       }
     }
   }
 }
 
+// Analyse approximative des couleurs du template officiel JIRAMA
+function isDelestageTemplate(img) {
+  return new Promise((resolve) => {
+    const image = new Image();
+    image.crossOrigin = 'anonymous';
+    image.onload = () => {
+      const canvas = document.createElement('canvas');
+      canvas.width = image.width;
+      canvas.height = image.height;
+      const ctx = canvas.getContext('2d');
+      if (!ctx) {
+        resolve(false);
+        return;
+      }
+      ctx.drawImage(image, 0, 0);
+      const sample = (x, y) => {
+        const data = ctx.getImageData(x, y, 1, 1).data;
+        return { r: data[0], g: data[1], b: data[2] };
+      };
+
+      // Points de contrôle relatifs
+      const w = image.width;
+      const h = image.height;
+      const topLeft = sample(Math.floor(0.1 * w), Math.floor(0.1 * h));
+      const topRight = sample(Math.floor(0.9 * w), Math.floor(0.1 * h));
+
+      console.debug('Couleurs échantillonnées', { topLeft, topRight });
+
+      // Couleur orange (en-tête) et bleu (date) approximatives
+      const isOrange = topLeft.r > 200 && topLeft.g > 100 && topLeft.b < 80;
+      const isBlue = topRight.b > 150 && topRight.r < 100 && topRight.g < 150;
+
+      resolve(isOrange && isBlue);
+    };
+    image.onerror = () => resolve(false);
+    image.src = img.src;
+  });
+}
+
 // Laisse la page charger un peu avant de chercher les posts
-setTimeout(checkDelestagePosts, 3000);
+setTimeout(() => {
+  checkDelestagePosts();
+}, 3000);
 


### PR DESCRIPTION
## Summary
- attempt to detect JIRAMA load-shedding image template via color sampling
- add extensive debug logs for text, image, and notifications

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b83ef7dd24832086fc6820ba13ac4d